### PR TITLE
fix:Point colab url to correct 02_resnet notebook

### DIFF
--- a/nbs/02_resnet.ipynb
+++ b/nbs/02_resnet.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![](https://raw.githubusercontent.com/butchland/fastai-torchgeo/master/assets/colab.svg)](https://colab.research.google.com/github/butchland/fastai-torchgeo/blob/master/nbs/01_data.ipynb)"
+    "[![](https://raw.githubusercontent.com/butchland/fastai-torchgeo/master/assets/colab.svg)](https://colab.research.google.com/github/butchland/fastai-torchgeo/blob/master/nbs/02_resnet.ipynb)"
    ]
   },
   {


### PR DESCRIPTION
* Fix colab url for 02_resnet notebook